### PR TITLE
feat: 반응형 설정을 위한 tailwind theme 설정

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -50,4 +50,19 @@
 
   /* 기본 둥글기 */
   --radius: 0.5rem; /* 사용법: rounded, rounded-lg (기본값) */
+
+  /* 반응형 breakpoint 지정 */
+  --breakpoint-sm: 400px;
+  --breakpoint-md: 600px;
+  --breakpoint-lg: 1020px;
+  --breakpoint-xl: 1350px;
+  --breakpoint-2xl: 1920px;
+
+  /* 폰트 사이즈 scale 지정 */
+  --text-8xl: 200px;
+  --text-7xl: 120px;
+  --text-6xl: 90px;
+  --text-5xl: 70px;
+  --text-4xl: 40px;
+  --text-3xl: 32px;
 }


### PR DESCRIPTION
## ✨ 요약

> PR의 목적을 한두 문장으로 요약합니다.

피그마에 있는 폰트 사이즈와 반응형 크기를 theme으로 사용하기 위해 tailwind css 설정을 진행하였습니다. 

## 🔗 작업 내용

- sm: 400px, md: 600px, lg: 1020px, xl: 1350px, 2xl: 1920px으로 지정
- 8xl: 200px, 7xl: 120px, 6xl: 90px, 5xl: 70px, 4xl: 40px, 3xl: 32px으로 지정( 나머지는 있는 값으로 사용 )

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

theme.css에 사용할 값들을 지정하였습니다. 

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #10 